### PR TITLE
Bug fixed unwanted initial position shiftings

### DIFF
--- a/FShake.cpp
+++ b/FShake.cpp
@@ -6,7 +6,7 @@
 USING_NS_CC;
 
 // not really useful, but I like clean default constructors
-FShake::FShake() : _strength_x(0), _strength_y(0), _initial_x(0), _initial_y(0)
+FShake::FShake() : _strength_x(0), _strength_y(0), _displacement_x(0), _displacement_y(0)
 {
 }
 
@@ -50,24 +50,27 @@ void FShake::update(float time)
 	float rand_x = fgRangeRand( -_strength_x, _strength_x );
 	float rand_y = fgRangeRand( -_strength_y, _strength_y );
 
+	auto target = this->getTarget();
+	auto currentPosition = target->getPosition();
+
 	// move the target to a shaked position
-	this->getTarget()->setPosition( Vec2( this->_initial_x+rand_x, this->_initial_y+rand_y) );
-}
+	target->setPosition(currentPosition.x - _displacement_x + rand_x,
+						currentPosition.y - _displacement_y + rand_y);
 
-void FShake::startWithTarget(Node *pTarget)
-{
-	ActionInterval::startWithTarget( pTarget );
-
-	// save the initial position
-	_initial_x = pTarget->getPosition().x;
-	_initial_y = pTarget->getPosition().y;
+	// Keep track of the last displacement
+	_displacement_x = rand_x;
+	_displacement_y = rand_y;
 }
 
 void FShake::stop(void)
 {
-	// Action is done, reset clip position
-	this->getTarget()->setPosition( Vec2( _initial_x, _initial_y ) );
+	auto target = this->getTarget();
+	auto currentPosition = target->getPosition();
 
+	// Action is done, reset clip position
+	target->setPosition(currentPosition.x - _displacement_x,
+						currentPosition.y - _displacement_y);
+	
 	ActionInterval::stop();
 }
 

--- a/FShake.h
+++ b/FShake.h
@@ -17,15 +17,14 @@ public:
 	static FShake* actionWithDuration(float d, float strength_x, float strength_y );
 	bool initWithDuration(float d, float strength_x, float strength_y );
 
-	virtual void startWithTarget(cocos2d::Node* pTarget);
 	virtual void update(float time);
 	virtual void stop(void);
         virtual FShake* clone();
 
 
 protected:
-	// Initial position of the shaked node
-	float _initial_x, _initial_y;
+	// Last displacement of the shaked node
+	float _displacement_x, _displacement_y;
 	// Strength of the action
 	float _strength_x, _strength_y;
 };


### PR DESCRIPTION
fixes #1 

Instead of storing initial positions at the start, in this version FShake stores the last displacement. What it does at every frame is basically;

Subtract last displacement vector from current position vector and move node back to it's original position
Calculate a new displacement vector
Move the node forward to new position
Store new displacement vector for the next frame

And when the stop() method called, it moves back the node as the amount of latest displacement, to the position where it starts to shake it. In this way FShake can make 0 it's net displacement over the target node and makes sure that it moves the node back the exact amount of it moved forward. 

Even multiple FShake's called on the same target node, each of their net displacement will be equal 0, and target node will appear at it's original position before the FShake actions. 

Tested under cocos2d-x v3.8 with the given scenerio in #1 
